### PR TITLE
Correct `utilitySelectors` RegEx typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Like so:
         "initial": "^\\.{componentName}(?:-[a-z]+)?$",
         "combined": "^\\.combined-{componentName}-[a-z]+$"
       },
-      "utilitySelectors": "^\.util-[a-z]+$"
+      "utilitySelectors": "^\\.util-[a-z]+$"
     },
     // ...
   }


### PR DESCRIPTION
Correct the regex given to `utilitySelectors` to double escape the period, fixes #7 