### PR TITLE
Add implicitComponents option. Fixes #24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
+  - "6"
   - "stable"

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var ruleName = 'plugin/selector-bem-pattern';
 
 var optionsSchema = {
   preset: ['suit', 'bem'],
-  presetOptions: function() { return true; }, // Can't currently validated `presetOptions`
+  presetOptions: function() { return true; }, // Can't currently validate `presetOptions`
   componentName: [isStringOrRegExp],
   componentSelectors: [function(pattern) {
     if (isStringOrFunction(pattern)) return true;
@@ -33,6 +33,7 @@ var optionsSchema = {
 
 module.exports = stylelint.createPlugin(ruleName, function(options) {
   return function(root, result) {
+    if (!options) return;
     var validOptions = stylelint.utils.validateOptions(result, ruleName, {
       actual: options,
       possible: optionsSchema,

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var optionsSchema = {
     return true;
   }],
   implicitComponents: [_.isBoolean, _.isString, function(pattern) {
-    return _.isArray(patttern) && _.every(pattern, _.isString);
+    return _.isArray(pattern) && _.every(pattern, _.isString);
   }],
   utilitySelectors: [isStringOrRegExp],
   ignoreSelectors: [

--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ var optionsSchema = {
     if (pattern.combined && !isStringOrFunction(pattern.combined)) return false;
     return true;
   }],
+  implicitComponents: [_.isBoolean, _.isString, function(pattern) {
+    return _.isArray(patttern) && _.every(pattern, _.isString);
+  }],
   utilitySelectors: [isStringOrRegExp],
   ignoreSelectors: [
     isStringOrRegExp,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/davidtheclark/stylelint-selector-bem-pattern#readme",
   "dependencies": {
     "lodash": ">=3.10.0",
-    "postcss": "^5.0.19",
+    "postcss": ">=5.0.19",
     "postcss-bem-linter": "^2.1.0",
     "stylelint": ">=3.0.2"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -93,10 +93,9 @@ testRule(selectorBemPattern.rule, {
   config: null,
   skipBasicChecks: true,
 
-  reject: [
+  accept: [
     {
-      code: 'a {}',
-      message: 'Expected option value for rule "' + selectorBemPattern.ruleName + '"',
+      code: '/** @define Foo */\na {}',
     },
   ],
 });


### PR DESCRIPTION
Added support for the `implicitComponents` option as detailed here:

https://github.com/postcss/postcss-bem-linter#define-components-and-utilities-implicitly-based-on-their-filename