### PR TITLE
Use root if no node for stylelint report for implicitComponents warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = stylelint.createPlugin(ruleName, function(options) {
       stylelint.utils.report({
         ruleName: ruleName,
         result: result,
-        node: warning.node,
+        node: warning.node || root,
         line: warning.line,
         column: warning.column,
         message: warning.text + ' (' + ruleName + ')',


### PR DESCRIPTION
Hi! Thanks for this plugin!

I've been trying to get `implicitComponents` to work and have been running into the following error:
```
TypeError: Cannot read property 'positionBy' of undefined
    at Object.module.exports [as report] (/Users/edwinzhang/co/backend/node_modules/stylelint/lib/utils/report.js:49:33)
    at /Users/edwinzhang/co/backend/node_modules/stylelint-selector-bem-pattern/index.js:57:23
    at Array.forEach (native)
    at /Users/edwinzhang/co/backend/node_modules/stylelint-selector-bem-pattern/index.js:56:23
    at Promise.resolve.then (/Users/edwinzhang/co/backend/node_modules/stylelint/lib/lintSource.js:161:9)
    at <anonymous>
```

It looks that `postcss-bem-linter` [does not provide a `node` or a `line`](https://github.com/postcss/postcss-bem-linter/blob/master/index.js#L114), as expected by the `stylelint.utils.report`, causing [this line](https://github.com/stylelint/stylelint/blob/master/lib/utils/report.js#L49) to fail.

I tested this locally and fixes the error in my linter (so the warnings print properly). The change here seemed a bit more appropriate here vs in `postcss-bem-linter` since this is a `stylelint` plugin, and the expectation of a `node | line` is more a stylelint demand than the linter's expectation. What do you think?